### PR TITLE
Padronização de controllers

### DIFF
--- a/infra/errors/errors.js
+++ b/infra/errors/errors.js
@@ -17,3 +17,22 @@ export class InternalServerError extends Error {
     };
   }
 }
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para esse endpoint.");
+    (this.name = "MethodNotAllowedError"),
+      (this.action =
+        "Verifique se o método HTTP enviado é válido para esse endpoint"),
+      (this.statusCode = 405);
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,12 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "^2.2.5"
+        "swr": "2.2.5"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -2448,6 +2449,12 @@
       "dependencies": {
         "@textlint/ast-node-types": "14.8.4"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -9623,6 +9630,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10775,6 +10795,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,46 +1,48 @@
-import migrationRunner from "node-pg-migrate";
-import { resolve } from "node:path";
 import database from "infra/database.js";
+import { createRouter } from "next-connect";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+} from "infra/errors/errors";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
+const router = createRouter();
 
-  if (!allowedMethods.includes(request.method)) {
-    return response
-      .status(405)
-      .json({ error: `Method "${request.method}" not allowed` });
-  }
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
 
-  const dbClient = await database.getNewClient();
+function onNoMatchHandler(request, response) {
+  const error = new MethodNotAllowedError();
 
-  try {
-    const defaultMigrationsOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
-
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner(defaultMigrationsOptions);
-      return response.status(201).json(pendingMigrations);
-    }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationsOptions,
-        dryRun: false,
-      });
-
-      return migratedMigrations.length > 0
-        ? response.status(201).json(migratedMigrations)
-        : response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    return response.status(405).end();
-  } finally {
-    await dbClient.end();
-  }
+  response.status(405).json(error);
 }
+
+function onErrorHandler(error, request, response) {
+  const publicError = new InternalServerError({ cause: error });
+
+  console.log("Erro dentro do catch do next-connect: Migrations");
+  console.error(publicError);
+
+  response.status(500).json(publicError);
+}
+
+router.get(async (request, response) => {
+  const pendingMigrations = await database.runMigrations({
+    dry_run: true,
+  });
+
+  response.status(201).json(pendingMigrations);
+});
+
+router.post(async (request, response) => {
+  const pendingMigrations = await database.runMigrations({
+    dry_run: false,
+  });
+
+  if (pendingMigrations.length > 0) {
+    response.status(201).json(pendingMigrations);
+  }
+
+  response.status(200).json(pendingMigrations);
+});

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,51 +1,66 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors/errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+} from "infra/errors/errors";
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
+const router = createRouter();
 
-    const dbName = process.env.POSTGRES_DB;
+router.get(status);
 
-    const pgVersionResult = await database.query("SHOW server_version;");
-    const pgVersioValue = pgVersionResult.rows[0].server_version;
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
 
-    const pgMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    );
-    const pgMaxConnectionValue = parseInt(
-      pgMaxConnectionsResult.rows[0].max_connections,
-    );
+function onNoMatchHandler(request, response) {
+  const error = new MethodNotAllowedError();
 
-    const pgActiveConnectionsResult = await database.query({
-      text: `SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1`,
-      values: [dbName],
-    });
-    const pgActiveConnectionValue = pgActiveConnectionsResult.rows[0].count;
-
-    const pgIdleConnectionsResult = await database.query(
-      `SELECT COUNT(*)::int FROM pg_stat_activity WHERE state = 'idle' AND datname = '${dbName}'`,
-    );
-    const pgIdleConnectionsValue = pgIdleConnectionsResult.rows[0].count;
-
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: pgVersioValue,
-          max_connections: pgMaxConnectionValue,
-          active_connections: pgActiveConnectionValue,
-          idle_connections: pgIdleConnectionsValue,
-        },
-      },
-    });
-  } catch (error) {
-    console.log("Error catch Controller");
-
-    const publicErrorObject = new InternalServerError({ cause: error });
-
-    response.status(500).json(publicErrorObject);
-  }
+  response.status(405).json(error);
 }
 
-export default status;
+function onErrorHandler(error, request, response) {
+  console.log("Error dentro do catch do next-connect");
+
+  const publicErrorObject = new InternalServerError({ cause: error });
+
+  response.status(500).json(publicErrorObject);
+}
+
+async function status(request, response) {
+  const updatedAt = new Date().toISOString();
+
+  const dbName = process.env.POSTGRES_DB;
+
+  const pgVersionResult = await database.query("SHOW server_version;");
+  const pgVersioValue = pgVersionResult.rows[0].server_version;
+
+  const pgMaxConnectionsResult = await database.query("SHOW max_connections;");
+  const pgMaxConnectionValue = parseInt(
+    pgMaxConnectionsResult.rows[0].max_connections,
+  );
+
+  const pgActiveConnectionsResult = await database.query({
+    text: `SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1`,
+    values: [dbName],
+  });
+  const pgActiveConnectionValue = pgActiveConnectionsResult.rows[0].count;
+
+  const pgIdleConnectionsResult = await database.query(
+    `SELECT COUNT(*)::int FROM pg_stat_activity WHERE state = 'idle' AND datname = '${dbName}'`,
+  );
+  const pgIdleConnectionsValue = pgIdleConnectionsResult.rows[0].count;
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: pgVersioValue,
+        max_connections: pgMaxConnectionValue,
+        active_connections: pgActiveConnectionValue,
+        idle_connections: pgIdleConnectionsValue,
+      },
+    },
+  });
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -21,7 +21,7 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-  console.log("Error dentro do catch do next-connect");
+  console.log("Error dentro do catch do next-connect: Status");
 
   const publicErrorObject = new InternalServerError({ cause: error });
 

--- a/tests/api/v1/migrations/delete.test.js
+++ b/tests/api/v1/migrations/delete.test.js
@@ -1,0 +1,20 @@
+describe("DELETE to /api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("should return 405", async () => {
+      const response = await fetch("http:localhost:3000/api/v1/migrations", {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para esse endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para esse endpoint",
+        status_code: 405,
+      });
+    });
+  });
+});

--- a/tests/api/v1/status/post.test.js
+++ b/tests/api/v1/status/post.test.js
@@ -6,15 +6,13 @@ beforeAll(async () => {
 
 describe("POST to /api/v1/status", () => {
   describe("Anonymous user", () => {
-    test("should return 200", async () => {
+    test("should return 405", async () => {
       const response = await fetch("http:localhost:3000/api/v1/status", {
         method: "POST",
       });
       expect(response.status).toBe(405);
 
       const responseBody = await response.json();
-
-      console.log(responseBody);
 
       expect(responseBody).toEqual({
         name: "MethodNotAllowedError",

--- a/tests/api/v1/status/post.test.js
+++ b/tests/api/v1/status/post.test.js
@@ -1,0 +1,28 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST to /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("should return 200", async () => {
+      const response = await fetch("http:localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      console.log(responseBody);
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para esse endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para esse endpoint",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1 - Padroniza os controllers `/migrations` e `/status`
2 - Adiciona 2 novos erros customizados: `MethodNotAllowed` e `ServiceError`
3 - Faz o `InternalServerError` aceitar injeção de statusCode